### PR TITLE
Use old constructor for java 1.8 compatibility

### DIFF
--- a/src/main/java/net/thiim/dilithium/provider/DilithiumProvider.java
+++ b/src/main/java/net/thiim/dilithium/provider/DilithiumProvider.java
@@ -6,7 +6,7 @@ import java.security.Provider;
 public class DilithiumProvider extends Provider {
 
 	public DilithiumProvider() {
-		super("Dilithium Provider", "0.1", "For experimental use only");
+		super("Dilithium Provider", 0.1, "For experimental use only");
 		
 		 AccessController.doPrivileged(new java.security.PrivilegedAction<Object>() {
 	            @Override


### PR DESCRIPTION
This was needed for me to use the library in an Android project. If you don't want to use a @deprecated method I understand, but all things considered I think it is a worthwhile change.